### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,5 +1,7 @@
 name: Code Coverage
 on: push
+permissions:
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Potential fix for [https://github.com/chotchki/tray-wrapper/security/code-scanning/1](https://github.com/chotchki/tray-wrapper/security/code-scanning/1)

To fix this issue, explicitly add a `permissions` block to the workflow configuration. This can be at the root level (applies to all jobs by default), or (redundantly) within each job. The best practice is to specify this at the workflow level, above the `jobs:` block. Since none of the steps writes to repository resources, the minimal required permission is `contents: read`. Add the following block after the workflow name and before the `on:` or after the `on:` block (either placement is accepted, but immediately after `on:` is more common and is shown in GitHub's own docs).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
